### PR TITLE
Use username rather than fullname

### DIFF
--- a/fa/api.py
+++ b/fa/api.py
@@ -46,11 +46,9 @@ def fetch_data(api_key, extra_args=''):
 
     return data
 
-def fetch_full_name(username):
+def fetch_name(username):
     user_data = fetch_data('user/{}'.format(username))
-    full_name = user_data['full_name']
-
-    return username if full_name == 'Not Available...' else full_name
+    return user_data['name']
 
 def fetch_first_image(username):
     gallery = fetch_data('user/{}/gallery'.format(username))
@@ -228,7 +226,7 @@ def get_profile_context(username):
     ]
 
     context = {
-        'name'      : fetch_full_name(username),
+        'name'      : fetch_name(username),
         'username'  : username,
         'user_url'  : user_data['profile'],
         'head_img'  : head_img,
@@ -264,7 +262,7 @@ def get_gallery_context(username, folder, page=1):
         gallery.append(img)
 
     context = {
-        'name'      : fetch_full_name(username),
+        'name'      : fetch_name(username),
         'username'  : username,
         'folder'    : folder,
         'gallery'   : gallery,
@@ -279,7 +277,7 @@ def get_watch_context(username, watch_view, page=1):
     watch_count     = len(watch_list)
     previous_page   = (page - 1) if page != 1 and watch_count > 0 else False
     next_page       = (page + 1) if watch_count > 0 else False
-    full_name       = fetch_full_name(username)
+    full_name       = fetch_name(username)
 
     if watch_view == 'watching':
         head = '{} is watching'.format(full_name)
@@ -306,7 +304,7 @@ def get_journals_context(username):
         journal['delta'] = natural_delta(journal['posted_at'], right_now)
 
     context = {
-        'name'      : fetch_full_name(username),
+        'name'      : fetch_name(username),
         'username'  : username,
         'journals'  : journals,
     }
@@ -358,7 +356,7 @@ def get_submission_context(subm_id):
             subm_data['audio_type'] = 'mpeg' if file_ext == 'mp3' else 'ogg'
 
     context = {
-        'name'      : fetch_full_name(username),
+        'name'      : fetch_name(username),
         'username'  : username,
         'sub_data'  : subm_data,
         'comments'  : subm_comments,
@@ -376,7 +374,7 @@ def get_journal_context(journ_id):
     journ_data['description']   = replace_media_urls(journ_data['description'])
 
     context = {
-        'name'      : fetch_full_name(username),
+        'name'      : fetch_name(username),
         'username'  : username,
         'journ_data': journ_data,
         'comments'  : journ_comments,


### PR DESCRIPTION
When the api was initially set up, the only available name field was `full_name` (2).  I've since added the field `name` to it (1).  This commit changes all user pages to use `name` for the display name.
![2015-05-21-003847_219x87_scrot](https://cloud.githubusercontent.com/assets/11081061/7743682/e8991ca2-ff51-11e4-8d65-2c03212309a3.png)

Before:
![2015-05-21-001814_502x436_scrot](https://cloud.githubusercontent.com/assets/11081061/7743378/01e33ee8-ff4f-11e4-9791-e4f7498278e4.png)

After:
![2015-05-21-001857_500x438_scrot](https://cloud.githubusercontent.com/assets/11081061/7743381/08be2296-ff4f-11e4-8fad-e60c7e6f574c.png)
